### PR TITLE
Fix deterministic UI rendering regressions and add-mode key leak

### DIFF
--- a/src/runtime/handlers.ts
+++ b/src/runtime/handlers.ts
@@ -80,6 +80,10 @@ export function createHandleKey(deps: HandleKeyDeps): (sequence: string) => bool
       return true;
     }
 
+    if (state.inputMode === "add") {
+      return false;
+    }
+
     if (sequence === "\u0003" || sequence === "q") {
       deps.quit();
     }

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -46,6 +46,10 @@ export function createUiLayout(
   renderer: Awaited<ReturnType<typeof createCliRenderer>>,
   tabCount: number,
 ): UiLayoutRefs {
+  const MODAL_BORDER_ROWS = 2;
+  const modalHeight = (contentRows: number, verticalPadding = 1): number =>
+    contentRows + MODAL_BORDER_ROWS + verticalPadding * 2;
+
   const root = renderer.root;
 
   const layout = new BoxRenderable(renderer, {
@@ -99,7 +103,13 @@ export function createUiLayout(
   const listLines: TextRenderable[] = [];
   const listRows = 17;
   for (let i = 0; i < listRows; i += 1) {
-    const line = new TextRenderable(renderer, { content: "", fg: colors.text, bg: colors.panelAlt });
+    const line = new TextRenderable(renderer, {
+      content: "",
+      fg: colors.text,
+      bg: colors.panelAlt,
+      wrapMode: "none",
+      truncate: true,
+    });
     listLines.push(line);
   }
 
@@ -114,7 +124,7 @@ export function createUiLayout(
   const centerTitle = new TextRenderable(renderer, { content: "DETAILS", fg: colors.highlight });
   const detailLines: TextRenderable[] = [];
   for (let i = 0; i < 12; i += 1) {
-    detailLines.push(new TextRenderable(renderer, { content: "", fg: colors.text }));
+    detailLines.push(new TextRenderable(renderer, { content: "", fg: colors.text, wrapMode: "none", truncate: true }));
   }
 
   const rightPanel = new BoxRenderable(renderer, {
@@ -141,7 +151,7 @@ export function createUiLayout(
   });
   const addModal = new BoxRenderable(renderer, {
     width: 60,
-    height: 5,
+    height: modalHeight(3),
     padding: 1,
     borderStyle: "double",
     borderColor: colors.borderStrong,
@@ -175,7 +185,7 @@ export function createUiLayout(
   });
   const runOptionsModal = new BoxRenderable(renderer, {
     width: 64,
-    height: 7,
+    height: modalHeight(7),
     padding: 1,
     borderStyle: "double",
     borderColor: colors.borderStrong,
@@ -212,7 +222,7 @@ export function createUiLayout(
   });
   const helpModal = new BoxRenderable(renderer, {
     width: 68,
-    height: 9,
+    height: modalHeight(7),
     padding: 1,
     borderStyle: "double",
     borderColor: colors.borderStrong,
@@ -422,7 +432,7 @@ export function createUiLayout(
 
   const footer = new BoxRenderable(renderer, {
     height: 2,
-    padding: 1,
+    padding: 0,
     gap: 2,
     backgroundColor: colors.panelRaised,
   });

--- a/test/runtime_handlers.test.ts
+++ b/test/runtime_handlers.test.ts
@@ -20,6 +20,7 @@ function createDeps() {
     loadData: 0,
     reloadData: 0,
     applyUpdatesAndSync: 0,
+    exitInputMode: 0,
     scrollPreview: [] as number[],
     enterInputMode: [] as Array<{ mode: "none" | "add" | "prompt" | "args" | "filter"; seed?: string }>,
   };
@@ -76,7 +77,9 @@ function createDeps() {
     enterInputMode: (mode, seed) => {
       calls.enterInputMode.push({ mode, seed });
     },
-    exitInputMode: () => {},
+    exitInputMode: () => {
+      calls.exitInputMode += 1;
+    },
     handleInputChar: () => {},
     installSelectedBulk: async () => {
       calls.installSelectedBulk += 1;
@@ -268,5 +271,17 @@ describe("runtime key handler", () => {
 
     expect(handleKey("f")).toBe(true);
     expect(calls.enterInputMode).toEqual([{ mode: "filter", seed: "" }]);
+  });
+
+  test("add input mode blocks global shortcuts while keeping add controls", () => {
+    const { state, calls, handleKey } = createDeps();
+    state.inputMode = "add";
+
+    expect(handleKey("q")).toBe(false);
+    expect(handleKey("i")).toBe(false);
+    expect(calls.enterInputMode).toHaveLength(0);
+
+    expect(handleKey("\x1b")).toBe(true);
+    expect(calls.exitInputMode).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
This PR fixes the deterministic UI/input regressions tracked in #16 and child issues #17-#20.

## Changes
- Compute modal heights from content rows + modal chrome using a shared helper.
- Apply computed heights to Add, Run Options, and Help modals.
- Enforce single-line list/detail row rendering with truncation to prevent wrapping overlap.
- Fix footer clipping by ensuring two footer lines fit in the footer container.
- Prevent global shortcut handling while in add-input mode so typing does not trigger app actions.
- Add regression coverage for add-mode keyboard ownership.

## Verification
- `bun test` (137 pass, 0 fail)
- `bun run typecheck`

Closes #16
Closes #17
Closes #18
Closes #19
Closes #20